### PR TITLE
ci: disable restriction on the commit max line length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', Infinity], // disable commit body length restriction
+  },
 }


### PR DESCRIPTION
This is to solve issues with commit linting the dependabot PRs like #27 #26 #25 