### PR TITLE
feat: add multilevel ens subdomain support

### DIFF
--- a/src/bzz-link.ts
+++ b/src/bzz-link.ts
@@ -1,5 +1,5 @@
-import { Request, Response } from 'express'
 import * as swarmCid from '@ethersphere/swarm-cid'
+import { Request, Response } from 'express'
 import { logger } from './logger'
 
 export class NotEnabledError extends Error {}
@@ -19,9 +19,8 @@ export class RedirectCidError extends Error {
  * @param pathname
  * @param req
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function requestFilter(pathname: string, req: Request): boolean {
-  return req.subdomains.length === 1
+  return req.subdomains.length >= 1
 }
 
 /**
@@ -81,7 +80,7 @@ export function errorHandler(err: Error, req: Request, res: Response, next: (e: 
  */
 function subdomainToBzz(req: Request, isCidEnabled: boolean, isEnsEnabled: boolean): string {
   const host = req.hostname.split('.')
-  const subdomain = host[0] // Taking the first subdomain from left
+  const subdomain = req.subdomains.join('.')
 
   try {
     const result = swarmCid.decodeCid(subdomain)

--- a/src/bzz-link.ts
+++ b/src/bzz-link.ts
@@ -80,7 +80,7 @@ export function errorHandler(err: Error, req: Request, res: Response, next: (e: 
  */
 function subdomainToBzz(req: Request, isCidEnabled: boolean, isEnsEnabled: boolean): string {
   const host = req.hostname.split('.')
-  const subdomain = req.subdomains.join('.')
+  const subdomain = [...req.subdomains].reverse().join('.')
 
   try {
     const result = swarmCid.decodeCid(subdomain)

--- a/src/bzz-link.ts
+++ b/src/bzz-link.ts
@@ -1,5 +1,5 @@
-import * as swarmCid from '@ethersphere/swarm-cid'
 import { Request, Response } from 'express'
+import * as swarmCid from '@ethersphere/swarm-cid'
 import { logger } from './logger'
 
 export class NotEnabledError extends Error {}

--- a/test/bzz-link.spec.ts
+++ b/test/bzz-link.spec.ts
@@ -50,6 +50,12 @@ describe('bzz.link', () => {
       expect(requestFilter('', req)).toStrictEqual(true)
     })
 
+    it('should return true for multilevel subdomain', async () => {
+      const req = { subdomains: ['swarm', 'book'] } as Request
+
+      expect(requestFilter('', req)).toStrictEqual(true)
+    })
+
     it('should return false for no subdomain', async () => {
       const req = { subdomains: [] as string[] } as Request
 
@@ -83,6 +89,13 @@ describe('bzz.link', () => {
       const req = { hostname: `some-ens-domain.bzz.link`, subdomains: ['some-ens-domain'] } as Request
 
       expect(router(req)).toEqual(`http://some.bee/bzz/some-ens-domain.eth`)
+    })
+
+    it('should translate valid ENS with subdomain', async () => {
+      const router = routerClosure('http://some.bee', true, true)
+      const req = { hostname: `book.swarm.bzz.link`, subdomains: ['swarm', 'book'] } as Request
+
+      expect(router(req)).toEqual(`http://some.bee/bzz/book.swarm.eth`)
     })
 
     it('should translate valid ENS when CID is disabled', async () => {

--- a/test/bzz-link.spec.ts
+++ b/test/bzz-link.spec.ts
@@ -1,8 +1,8 @@
-import { NotEnabledError, RedirectCidError, requestFilter, routerClosure } from '../src/bzz-link'
 import { Application, Request } from 'express'
 import { Server } from 'http'
 import { AddressInfo } from 'net'
 import request from 'supertest'
+import { NotEnabledError, RedirectCidError, requestFilter, routerClosure } from '../src/bzz-link'
 import { DEFAULT_BEE_DEBUG_API_URL } from '../src/config'
 import { createApp } from '../src/server'
 import { createBzzLinkMockServer } from './bzz-link.mockserver'
@@ -66,35 +66,40 @@ describe('bzz.link', () => {
 
     it('should translate valid CID', async () => {
       const router = routerClosure('http://some.bee', true, true)
-      const req = { hostname: `${MANIFEST.cid}.bzz.link` } as Request
+      const req = { hostname: `${MANIFEST.cid}.bzz.link`, subdomains: [MANIFEST.cid] } as Request
 
       expect(router(req)).toEqual(`http://some.bee/bzz/${MANIFEST.reference}`)
     })
 
     it('should translate valid CID with ENS disabled', async () => {
       const router = routerClosure('http://some.bee', true, false)
-      const req = { hostname: `${MANIFEST.cid}.bzz.link` } as Request
+      const req = { hostname: `${MANIFEST.cid}.bzz.link`, subdomains: [MANIFEST.cid] } as Request
 
       expect(router(req)).toEqual(`http://some.bee/bzz/${MANIFEST.reference}`)
     })
 
     it('should translate valid ENS', async () => {
       const router = routerClosure('http://some.bee', true, true)
-      const req = { hostname: `some-ens-domain.bzz.link` } as Request
+      const req = { hostname: `some-ens-domain.bzz.link`, subdomains: ['some-ens-domain'] } as Request
 
       expect(router(req)).toEqual(`http://some.bee/bzz/some-ens-domain.eth`)
     })
 
     it('should translate valid ENS when CID is disabled', async () => {
       const router = routerClosure('http://some.bee', false, true)
-      const req = { hostname: `some-ens-domain.bzz.link` } as Request
+      const req = { hostname: `some-ens-domain.bzz.link`, subdomains: ['some-ens-domain'] } as Request
 
       expect(router(req)).toEqual(`http://some.bee/bzz/some-ens-domain.eth`)
     })
 
     it('should throw redirection error for legacy CID', async () => {
       const router = routerClosure('http://some.bee', true, true)
-      const req = { hostname: `${MANIFEST.legacyCid}.bzz.link`, protocol: 'http', originalUrl: '/' } as Request
+      const req = {
+        hostname: `${MANIFEST.legacyCid}.bzz.link`,
+        protocol: 'http',
+        originalUrl: '/',
+        subdomains: [MANIFEST.legacyCid],
+      } as Request
 
       try {
         router(req)
@@ -110,14 +115,14 @@ describe('bzz.link', () => {
 
     it('should throw when CID support is disabled', async () => {
       const router = routerClosure('http://some.bee', false, true)
-      const req = { hostname: `${MANIFEST.cid}.bzz.link` } as Request
+      const req = { hostname: `${MANIFEST.cid}.bzz.link`, subdomains: [MANIFEST.cid] } as Request
 
       expect(() => router(req)).toThrow(NotEnabledError)
     })
 
     it('should throw when ENS support is disabled', async () => {
       const router = routerClosure('http://some.bee', true, false)
-      const req = { hostname: `some-ens-domain.bzz.link` } as Request
+      const req = { hostname: `some-ens-domain.bzz.link`, subdomains: ['some-ens-domain'] } as Request
 
       expect(() => router(req)).toThrow(NotEnabledError)
     })


### PR DESCRIPTION
Env:

`HOSTNAME=bzz-link.local ENS_SUBDOMAINS=true`

---

`/etc/hosts`:

```
127.0.0.1               bzz-link.local
127.0.0.1      darkobas.bzz-link.local
127.0.0.1 blog.darkobas.bzz-link.local
```

---

Testnet:

```
mainnet: false,
'data-dir': join(location, 'data-dir-testnet'),
'swap-enable': false,
'swap-endpoint': '',
'resolver-options': goerliEnsResolver,
bootnode: '/dnsaddr/testnet.ethswarm.org'
```

---

Sample ETH domains:

`darkobas.eth` `->` `http://darkobas.bzz-link.local:3000/`

`blog.darkobas.eth` `->` `http://blog.darkobas.bzz-link.local:3000/`