### PR TITLE
feat: reupload pinned content periodically

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ npm run start
 | REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
 reupload.                                                            |
 | POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
+| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
+reupload.                                                            |
 
 ### Curl
 
@@ -179,22 +181,24 @@ curl \
 
 ## API
 
-| Endpoint                           | Response code     | Response text                                                                                                           |
-| ---------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `GET /health`                      | `200`             | `OK`                                                                                                                    |
-|                                    | `403`             | `Forbidden`                                                                                                             |
-| `GET /readiness`                   | `200`             | `OK`                                                                                                                    |
-|                                    | `403`             | `Forbidden`                                                                                                             |
-|                                    | `502`             | `Bad Gateway` when can not connect to Bee node                                                                          |
-| `GET /bzz/:swarmhash`              | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/BZZ/paths/~1bzz~1{reference}/get)                   |
-| `POST /bzz`                        | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/BZZ/paths/~1bzz/post)                               |
-| `GET /bytes/:swarmhash`            | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)               |
-| `POST /bytes`                      | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes/post)                           |
-| `GET /chunks/:swarmhash`           | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Chunk/paths/~1chunks~1{reference}/get)              |
-| `POST /chunks`                     | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Chunk/paths/~1chunks/post)                          |
-| `POST /soc/:owner/:id`             | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Single-owner-chunk/paths/~1soc~1{owner}~1{id}/post) |
-| `GET /feeds/:owner/:topic`         | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/get)           |
-| `POST /feeds/:owner/:topic`        | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/post)          |
+| Endpoint                    | Response code     | Response text                                                                                                           |
+| --------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `GET /health`               | `200`             | `OK`                                                                                                                    |
+|                             | `403`             | `Forbidden`                                                                                                             |
+| `GET /readiness`            | `200`             | `OK`                                                                                                                    |
+|                             | `403`             | `Forbidden`                                                                                                             |
+|                             | `502`             | `Bad Gateway` when can not connect to Bee node                                                                          |
+| `GET /bzz/:swarmhash`       | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/BZZ/paths/~1bzz~1{reference}/get)                   |
+| `POST /bzz`                 | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/BZZ/paths/~1bzz/post)                               |
+| `GET /bytes/:swarmhash`     | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes~1{reference}/get)               |
+| `POST /bytes`               | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Bytes/paths/~1bytes/post)                           |
+| `GET /chunks/:swarmhash`    | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Chunk/paths/~1chunks~1{reference}/get)              |
+| `POST /chunks`              | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Chunk/paths/~1chunks/post)                          |
+| `POST /soc/:owner/:id`      | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Single-owner-chunk/paths/~1soc~1{owner}~1{id}/post) |
+| `GET /feeds/:owner/:topic`  | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/get)           |
+| `POST /feeds/:owner/:topic` | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/post)          |
+| `PUT /pins`                 | `200`, `400`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Pinning/paths/~1pins/get)          |
+| `PUT /stewardship/:id`      | `200`, `400`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Stewardship/paths/~1stewardship~1{reference}/put)          |
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ export BEE_DEBUG_API_URL=http://localhost:1635
 npm run start
 ```
 
+#### 5. Reupload pinned content (Live Bee API)
+
+```sh
+export REUPLOAD_PERIOD=20000
+export BEE_DEBUG_API_URL=http://localhost:1633
+
+npm run start
+```
 #### Enable authentication
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ The proxy can manage postage stamps for you in 4 modes of operation:
 4. It can extend the TTL of a stamp that is about to expire. To enable this, set `POSTAGE_EXTENDSTTL=true`,
    provide `POSTAGE_AMOUNT`, `POSTAGE_DEPTH` with the desired amount to use and `POSTAGE_TTL_MIN` above with
    a number above or equal to 60.
-5. It can reupload existing pinned content that appear as not retrievable. To enable this, provide `REAUPLOAD_PERIOD`
-   with the miliseconds that represent the time to periodicaly check pinned content status
 
 In modes 1, 2 and 3, the proxy can be configured to require authentication secret to forward the requests. Use the
 `AUTH_SECRET` environment variable to enable it.
@@ -70,6 +68,11 @@ allows to have better security model for your web applications.
 
 In order to use Bzz.link, set the `HOSTNAME` environment variable, and either or both of `CID_SUBDOMAINS` and
 `ENS_SUBDOMAINS` according to your requirements. You may also need to set up DNS with wildcard subdomain support.
+
+### Reupload pinned content
+
+It can reupload existing pinned content that appear as not retrievable. To enable this, provide `REAUPLOAD_PERIOD`
+with the miliseconds that represent the time to periodicaly check pinned content status.
 
 ### Examples
 
@@ -109,7 +112,7 @@ export BEE_DEBUG_API_URL=http://localhost:1635
 npm run start
 ```
 
-#### 5. Reupload pinned content (Live Bee API)
+#### Reupload pinned content
 
 ```sh
 export REUPLOAD_PERIOD=30000
@@ -147,9 +150,6 @@ npm run start
 | `LOG_LEVEL`             | info                        | Log level that is outputted (values: `critical`, `error`, `warn`, `info`, `verbose`, `debug`)              |
 | POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 | EXPOSE_HASHED_IDENTITY  | false                       | Exposes `x-bee-node` header, which is the hashed identity of the Bee node for identification purposes      |
-| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
-reupload.                                                            |
-| POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 | REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
 reupload.                                                            |
 

--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ curl \
 | `POST /soc/:owner/:id`      | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Single-owner-chunk/paths/~1soc~1{owner}~1{id}/post) |
 | `GET /feeds/:owner/:topic`  | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/get)           |
 | `POST /feeds/:owner/:topic` | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/post)          |
-| `PUT /pins`                 | `200`, `400`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Pinning/paths/~1pins/get)          |
-| `PUT /stewardship/:id`      | `200`, `400`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Stewardship/paths/~1stewardship~1{reference}/put)          |
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd gateway-proxy
 
 ## Usage
 
-The proxy can manage postage stamps for you in 3 modes of operation:
+The proxy can manage postage stamps for you in 4 modes of operation:
 
 1. It can just proxy requests without manipulating the request
 2. It can add/replace the request postage stamp with one provided through environment variable `POSTAGE_STAMP`
@@ -56,6 +56,8 @@ The proxy can manage postage stamps for you in 3 modes of operation:
 4. It can extend the TTL of a stamp that is about to expire. To enable this, set `POSTAGE_EXTENDSTTL=true`,
    provide `POSTAGE_AMOUNT`, `POSTAGE_DEPTH` with the desired amount to use and `POSTAGE_TTL_MIN` above with
    a number above or equal to 60.
+5. It can reupload existing pinned content that appear as not retrievable. To enable this, provide `REAUPLOAD_PERIOD`
+   with the miliseconds to periodicaly check pinned content
 
 In modes 1, 2 and 3, the proxy can be configured to require authentication secret to forward the requests. Use the
 `AUTH_SECRET` environment variable to enable it.
@@ -145,6 +147,8 @@ npm run start
 | `LOG_LEVEL`             | info                        | Log level that is outputted (values: `critical`, `error`, `warn`, `info`, `verbose`, `debug`)              |
 | POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 | EXPOSE_HASHED_IDENTITY  | false                       | Exposes `x-bee-node` header, which is the hashed identity of the Bee node for identification purposes      |
+| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
+reupload.                                                            |
 
 ### Curl
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ npm run start
 | `LOG_LEVEL`             | info                        | Log level that is outputted (values: `critical`, `error`, `warn`, `info`, `verbose`, `debug`)              |
 | POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 | EXPOSE_HASHED_IDENTITY  | false                       | Exposes `x-bee-node` header, which is the hashed identity of the Bee node for identification purposes      |
-| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
+| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned content checked to be
 reupload.                                                            |
 
 ### Curl

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ npm run start
 #### 5. Reupload pinned content (Live Bee API)
 
 ```sh
-export REUPLOAD_PERIOD=20000
-export BEE_DEBUG_API_URL=http://localhost:1633
+export REUPLOAD_PERIOD=30000
 
 npm run start
 ```

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ npm run start
 | `LOG_LEVEL`             | info                        | Log level that is outputted (values: `critical`, `error`, `warn`, `info`, `verbose`, `debug`)              |
 | POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 | EXPOSE_HASHED_IDENTITY  | false                       | Exposes `x-bee-node` header, which is the hashed identity of the Bee node for identification purposes      |
-| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned content checked to be
-reupload.                                                            |
+| REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned content checked to be reuploaded.                                            |
 
 ### Curl
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The proxy can manage postage stamps for you in 4 modes of operation:
    provide `POSTAGE_AMOUNT`, `POSTAGE_DEPTH` with the desired amount to use and `POSTAGE_TTL_MIN` above with
    a number above or equal to 60.
 5. It can reupload existing pinned content that appear as not retrievable. To enable this, provide `REAUPLOAD_PERIOD`
-   with the miliseconds to periodicaly check pinned content
+   with the miliseconds that represent the time to periodicaly check pinned content status
 
 In modes 1, 2 and 3, the proxy can be configured to require authentication secret to forward the requests. Use the
 `AUTH_SECRET` environment variable to enable it.
@@ -116,6 +116,7 @@ export REUPLOAD_PERIOD=30000
 
 npm run start
 ```
+
 #### Enable authentication
 
 ```sh
@@ -148,6 +149,7 @@ npm run start
 | EXPOSE_HASHED_IDENTITY  | false                       | Exposes `x-bee-node` header, which is the hashed identity of the Bee node for identification purposes      |
 | REUPLOAD_PERIOD         | undefined                   | How frequently are the pinned contents checked to be
 reupload.                                                            |
+| POSTAGE_EXTENDSTTL      | false                       | Enables extends TTL feature. Works along with POSTAGE_AMOUNT                                               |
 
 ### Curl
 
@@ -193,7 +195,6 @@ curl \
 | `POST /soc/:owner/:id`             | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Single-owner-chunk/paths/~1soc~1{owner}~1{id}/post) |
 | `GET /feeds/:owner/:topic`         | `200`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/get)           |
 | `POST /feeds/:owner/:topic`        | `201`, `403`, ... | See official [bee documentation](https://docs.ethswarm.org/api/#tag/Feed/paths/~1feeds~1{owner}~1{topic}/post)          |
-
 
 ## Contribute
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,6 @@ export interface StampsConfigExtends {
 }
 
 export interface ContentsConfigReupload {
-  mode: 'reupload'
   beeDebugApiUrl: string
   refreshPeriod: number
 }
@@ -137,7 +136,6 @@ export function getStampsConfig({
   POSTAGE_TTL_MIN,
   POSTAGE_REFRESH_PERIOD,
   POSTAGE_EXTENDSTTL,
-  REUPLOAD_PERIOD,
 }: EnvironmentVariables = {}): StampsConfig | undefined {
   const refreshPeriod = Number(POSTAGE_REFRESH_PERIOD || DEFAULT_POSTAGE_REFRESH_PERIOD)
   const beeDebugApiUrl = BEE_DEBUG_API_URL || DEFAULT_BEE_DEBUG_API_URL
@@ -145,33 +143,7 @@ export function getStampsConfig({
   // Start in hardcoded mode
   if (POSTAGE_STAMP) return { mode: 'hardcoded', stamp: POSTAGE_STAMP }
   // Start autobuy
-  else {
-    return validateConfigMode(
-      BEE_DEBUG_API_URL,
-      POSTAGE_DEPTH,
-      POSTAGE_AMOUNT,
-      POSTAGE_USAGE_THRESHOLD,
-      POSTAGE_USAGE_MAX,
-      POSTAGE_TTL_MIN,
-      POSTAGE_EXTENDSTTL,
-      REUPLOAD_PERIOD,
-      refreshPeriod,
-    )
-  }
-}
-
-export function validateConfigMode(
-  BEE_DEBUG_API_URL: string | undefined,
-  POSTAGE_DEPTH: string | undefined,
-  POSTAGE_AMOUNT: string | undefined,
-  POSTAGE_USAGE_THRESHOLD: string | undefined,
-  POSTAGE_USAGE_MAX: string | undefined,
-  POSTAGE_TTL_MIN: string | undefined,
-  POSTAGE_EXTENDSTTL: string | undefined,
-  REUPLOAD_PERIOD: string | undefined,
-  refreshPeriod: number,
-): StampsConfig | undefined {
-  if (!POSTAGE_EXTENDSTTL && POSTAGE_DEPTH && POSTAGE_AMOUNT && BEE_DEBUG_API_URL) {
+  else if (!POSTAGE_EXTENDSTTL && POSTAGE_DEPTH && POSTAGE_AMOUNT && BEE_DEBUG_API_URL) {
     return {
       mode: 'autobuy',
       depth: Number(POSTAGE_DEPTH),
@@ -214,7 +186,6 @@ export function getContentsConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: Enviro
   | ContentsConfig
   | undefined {
   return {
-    mode: 'reupload',
     beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
     refreshPeriod: Number(REUPLOAD_PERIOD),
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -182,9 +182,7 @@ export function getStampsConfig({
   return undefined
 }
 
-export function getContentConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: EnvironmentVariables = {}):
-  | ContentConfig
-  | undefined {
+export function getContentConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: EnvironmentVariables = {}): ContentConfig {
   return {
     beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
     refreshPeriod: Number(REUPLOAD_PERIOD),

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,12 @@ export interface StampsConfigExtends {
   ttlMin: number
   depth: number
   amount: string
+  refreshPeriod: number
+  beeDebugApiUrl: string
+}
+
+export interface StampsConfigReupload {
+  mode: 'reupload'
   beeDebugApiUrl: string
   refreshPeriod: number
 }
@@ -218,7 +224,4 @@ export function validateConfigMode(
       }or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
     )
   }
-
-  // Stamps rewrite is disabled
-  return undefined
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -201,8 +201,8 @@ export function validateConfigMode(
   else if (POSTAGE_DEPTH || POSTAGE_AMOUNT || POSTAGE_TTL_MIN || BEE_DEBUG_API_URL) {
     throw new Error(
       `config: please provide POSTAGE_DEPTH=${POSTAGE_DEPTH}, POSTAGE_AMOUNT=${POSTAGE_AMOUNT}, POSTAGE_TTL_MIN=${POSTAGE_TTL_MIN} ${
-        POSTAGE_EXTENDSTTL === 'true' ? 'at least 60 seconds' : ''
-      } or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
+        POSTAGE_EXTENDSTTL === 'true' ? 'at least 60 seconds ' : ''
+      }or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
     )
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,8 +197,8 @@ export function validateConfigMode(
     }
   } else if (REUPLOAD_PERIOD) {
     return {
-      beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
       mode: 'reupload',
+      beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
       refreshPeriod: Number(REUPLOAD_PERIOD),
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,22 +27,7 @@ export interface StampsConfigExtends {
   beeDebugApiUrl: string
 }
 
-export interface StampsConfigReupload {
-  mode: 'reupload'
-  beeDebugApiUrl: string
-  refreshPeriod: number
-}
-
-export interface StampsConfigExtends {
-  mode: 'extendsTTL'
-  ttlMin: number
-  depth: number
-  amount: string
-  refreshPeriod: number
-  beeDebugApiUrl: string
-}
-
-export interface StampsConfigReupload {
+export interface ContentsConfigReupload {
   mode: 'reupload'
   beeDebugApiUrl: string
   refreshPeriod: number
@@ -59,7 +44,9 @@ export interface StampsConfigAutobuy {
   refreshPeriod: number
 }
 
-export type StampsConfig = StampsConfigHardcoded | StampsConfigAutobuy | StampsConfigExtends | StampsConfigReupload
+export type StampsConfig = StampsConfigHardcoded | StampsConfigAutobuy | StampsConfigExtends
+
+export type ContentsConfig = ContentsConfigReupload
 
 export type EnvironmentVariables = Partial<{
   // Logging
@@ -102,7 +89,7 @@ export type SupportedLevels = typeof SUPPORTED_LEVELS[number]
 export const DEFAULT_BEE_API_URL = 'http://localhost:1633'
 export const DEFAULT_BEE_DEBUG_API_URL = 'http://localhost:1635'
 export const DEFAULT_HOSTNAME = 'localhost'
-export const DEFAULT_PORT = 3001
+export const DEFAULT_PORT = 3000
 export const DEFAULT_POSTAGE_USAGE_THRESHOLD = 0.7
 export const DEFAULT_POSTAGE_USAGE_MAX = 0.9
 export const DEFAULT_POSTAGE_REFRESH_PERIOD = 60_000
@@ -209,22 +196,26 @@ export function validateConfigMode(
       refreshPeriod,
       beeDebugApiUrl,
     }
-  } else if (REUPLOAD_PERIOD) {
-    return {
-      mode: 'reupload',
-      beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
-      refreshPeriod: Number(REUPLOAD_PERIOD),
-    }
   }
   // Missing one of the variables needed for the autobuy or extends TTL
   else if (POSTAGE_DEPTH || POSTAGE_AMOUNT || POSTAGE_TTL_MIN || BEE_DEBUG_API_URL) {
     throw new Error(
       `config: please provide POSTAGE_DEPTH=${POSTAGE_DEPTH}, POSTAGE_AMOUNT=${POSTAGE_AMOUNT}, POSTAGE_TTL_MIN=${POSTAGE_TTL_MIN} ${
-        POSTAGE_EXTENDSTTL === 'true' ? 'at least 60 seconds ' : ''
-      }or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
+        POSTAGE_EXTENDSTTL === 'true' ? 'at least 60 seconds' : ''
+      } or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
     )
   }
 
   // Stamps rewrite is disabled
   return undefined
+}
+
+export function getContentsConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: EnvironmentVariables = {}):
+  | ContentsConfig
+  | undefined {
+  return {
+    mode: 'reupload',
+    beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,
+    refreshPeriod: Number(REUPLOAD_PERIOD),
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,4 +224,7 @@ export function validateConfigMode(
       }or BEE_DEBUG_API_URL=${BEE_DEBUG_API_URL} for the feature to work`,
     )
   }
+
+  // Stamps rewrite is disabled
+  return undefined
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,14 @@ interface StampsConfigHardcoded {
   mode: 'hardcoded'
   stamp: string
 }
+export interface StampsConfigExtends {
+  mode: 'extendsTTL'
+  ttlMin: number
+  depth: number
+  amount: string
+  beeDebugApiUrl: string
+  refreshPeriod: number
+}
 
 export interface StampsConfigExtends {
   mode: 'extendsTTL'

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export interface StampsConfigExtends {
   beeDebugApiUrl: string
 }
 
-export interface ContentsConfigReupload {
+export interface ContentConfigReupload {
   beeDebugApiUrl: string
   refreshPeriod: number
 }
@@ -45,7 +45,7 @@ export interface StampsConfigAutobuy {
 
 export type StampsConfig = StampsConfigHardcoded | StampsConfigAutobuy | StampsConfigExtends
 
-export type ContentsConfig = ContentsConfigReupload
+export type ContentConfig = ContentConfigReupload
 
 export type EnvironmentVariables = Partial<{
   // Logging
@@ -182,8 +182,8 @@ export function getStampsConfig({
   return undefined
 }
 
-export function getContentsConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: EnvironmentVariables = {}):
-  | ContentsConfig
+export function getContentConfig({ BEE_DEBUG_API_URL, REUPLOAD_PERIOD }: EnvironmentVariables = {}):
+  | ContentConfig
   | undefined {
   return {
     beeDebugApiUrl: BEE_DEBUG_API_URL || DEFAULT_BEE_API_URL,

--- a/src/content.ts
+++ b/src/content.ts
@@ -13,11 +13,8 @@ register.registerMetric(contentReuploadCounter)
 export class ContentManager {
   private interval?: ReturnType<typeof setInterval>
   private isReuploading?: boolean = false
-  private counter = 0
 
   public async refreshContentReupload(beeApi: Bee): Promise<void> {
-    logger.info(`contador ${this.counter}`)
-    this.counter += 1
     const pins = await beeApi.getAllPins()
 
     if (!pins.length) {
@@ -32,6 +29,7 @@ export class ContentManager {
           this.isReuploading = true
           await beeApi.reuploadPinnedData(pin)
           this.isReuploading = false
+          contentReuploadCounter.inc()
           logger.info(`pinned content reuploaded: ${pin}`)
         }
       }
@@ -39,7 +37,7 @@ export class ContentManager {
   }
 
   /**
-   * Start the manager to upload pinned content
+   * Start the manager that checks for pinned content availability and reuploads the data if needed.
    */
   async start(config: ContentConfig): Promise<void> {
     const refreshContent = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,6 +1,6 @@
 import { Bee } from '@ethersphere/bee-js'
 import client from 'prom-client'
-import type { ContentsConfig } from './config'
+import type { ContentConfig } from './config'
 import { logger } from './logger'
 import { register } from './metrics'
 
@@ -10,7 +10,7 @@ const contentReuploadCounter = new client.Counter({
 })
 register.registerMetric(contentReuploadCounter)
 
-export class ContentsManager {
+export class ContentManager {
   private interval?: ReturnType<typeof setInterval>
   private isReuploading?: boolean = false
   private counter = 0
@@ -41,12 +41,12 @@ export class ContentsManager {
   /**
    * Start the manager to upload pinned content
    */
-  async start(config: ContentsConfig): Promise<void> {
-    const refreshContents = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))
+  async start(config: ContentConfig): Promise<void> {
+    const refreshContent = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))
     this.stop()
-    await refreshContents()
+    await refreshContent()
 
-    this.interval = setInterval(refreshContents, config.refreshPeriod)
+    this.interval = setInterval(refreshContent, config.refreshPeriod)
   }
 
   stop(): void {

--- a/src/content.ts
+++ b/src/content.ts
@@ -19,18 +19,20 @@ export class ContentManager {
 
     if (!pins.length) {
       logger.info(`no pins found`)
-    } else {
-      logger.info(`checking pinned content (${pins.length} pins)`)
-      for (const pin of pins) {
-        const isRetrievable = await beeApi.isReferenceRetrievable(pin)
 
-        if (!isRetrievable && !this.isReuploading) {
-          this.isReuploading = true
-          await beeApi.reuploadPinnedData(pin)
-          this.isReuploading = false
-          contentReuploadCounter.inc()
-          logger.info(`pinned content reuploaded: ${pin}`)
-        }
+      return
+    }
+
+    logger.info(`checking pinned content (${pins.length} pins)`)
+    for (const pin of pins) {
+      const isRetrievable = await beeApi.isReferenceRetrievable(pin)
+
+      if (!isRetrievable && !this.isReuploading) {
+        this.isReuploading = true
+        await beeApi.reuploadPinnedData(pin)
+        this.isReuploading = false
+        contentReuploadCounter.inc()
+        logger.info(`pinned content reuploaded: ${pin}`)
       }
     }
   }
@@ -38,10 +40,10 @@ export class ContentManager {
   /**
    * Start the manager that checks for pinned content availability and reuploads the data if needed.
    */
-  async start(config: ContentConfig): Promise<void> {
+  start(config: ContentConfig): void {
     const refreshContent = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))
     this.stop()
-    await refreshContent()
+    refreshContent()
 
     this.interval = setInterval(refreshContent, config.refreshPeriod)
   }

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,7 +12,7 @@ register.registerMetric(contentReuploadCounter)
 
 export class ContentManager {
   private interval?: ReturnType<typeof setInterval>
-  private isReuploading?: boolean = false
+  private isReuploading = false
 
   public async refreshContentReupload(beeApi: Bee): Promise<void> {
     const pins = await beeApi.getAllPins()
@@ -21,8 +21,7 @@ export class ContentManager {
       logger.info(`no pins found`)
     } else {
       logger.info(`checking pinned content (${pins.length} pins)`)
-      for (let i = 0; i < pins.length; i++) {
-        const pin = pins[i]
+      for (const pin of pins) {
         const isRetrievable = await beeApi.isReferenceRetrievable(pin)
 
         if (!isRetrievable && !this.isReuploading) {

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -1,0 +1,54 @@
+import { Bee } from '@ethersphere/bee-js'
+import client from 'prom-client'
+import type { ContentsConfig } from './config'
+import { logger } from './logger'
+import { register } from './metrics'
+
+const contentReuploadCounter = new client.Counter({
+  name: 'content_reupload_counter',
+  help: 'How many pinned content items were uploaded',
+})
+register.registerMetric(contentReuploadCounter)
+
+export class ContentsManager {
+  private interval?: ReturnType<typeof setInterval>
+  private isReuploading?: boolean = false
+
+  public async refreshContentReupload(beeApi: Bee): Promise<void> {
+    const pins = await beeApi.getAllPins()
+
+    if (!pins.length) {
+      logger.info(`no pins found`)
+    } else {
+      logger.info(`checking pinned content (${pins.length} pins)`)
+      pins.forEach(async pin => {
+        const isRetrievable = await beeApi.isReferenceRetrievable(pin)
+
+        if (!isRetrievable && !this.isReuploading) {
+          this.isReuploading = true
+          await beeApi.reuploadPinnedData(pin)
+          this.isReuploading = false
+          logger.info(`pinned content reuploaded: ${pin}`)
+        }
+      })
+    }
+  }
+
+  /**
+   * Start the manager in either hardcoded or autobuy mode
+   */
+  async start(config: ContentsConfig): Promise<void> {
+    const refreshContents = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))
+    this.stop()
+    await refreshContents()
+
+    this.interval = setInterval(refreshContents, config.refreshPeriod)
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval)
+      this.interval = undefined
+    }
+  }
+}

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -13,15 +13,19 @@ register.registerMetric(contentReuploadCounter)
 export class ContentsManager {
   private interval?: ReturnType<typeof setInterval>
   private isReuploading?: boolean = false
+  private counter = 0
 
   public async refreshContentReupload(beeApi: Bee): Promise<void> {
+    logger.info(`contador ${this.counter}`)
+    this.counter += 1
     const pins = await beeApi.getAllPins()
 
     if (!pins.length) {
       logger.info(`no pins found`)
     } else {
       logger.info(`checking pinned content (${pins.length} pins)`)
-      pins.forEach(async pin => {
+      for (let i = 0; i < pins.length; i++) {
+        const pin = pins[i]
         const isRetrievable = await beeApi.isReferenceRetrievable(pin)
 
         if (!isRetrievable && !this.isReuploading) {
@@ -30,12 +34,12 @@ export class ContentsManager {
           this.isReuploading = false
           logger.info(`pinned content reuploaded: ${pin}`)
         }
-      })
+      }
     }
   }
 
   /**
-   * Start the manager in either hardcoded or autobuy mode
+   * Start the manager to upload pinned content
    */
   async start(config: ContentsConfig): Promise<void> {
     const refreshContents = async () => this.refreshContentReupload(new Bee(config.beeDebugApiUrl))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,14 @@ import { Application } from 'express'
 
 import { createApp } from './server'
 import { StampsManager } from './stamps'
-import { getAppConfig, getServerConfig, getStampsConfig, EnvironmentVariables } from './config'
+import { getAppConfig, getServerConfig, getStampsConfig, EnvironmentVariables, getContentsConfig } from './config'
 import { logger, subscribeLogServerRequests } from './logger'
+import { ContentsManager } from './contents'
 
 async function main() {
   // Configuration
-  const stampConfig = getStampsConfig(process.env as EnvironmentVariables)
+  const stampsConfig = getStampsConfig(process.env as EnvironmentVariables)
+  const contentsConfig = getContentsConfig(process.env as EnvironmentVariables)
   const appConfig = getAppConfig(process.env as EnvironmentVariables)
   const { hostname, port } = getServerConfig(process.env as EnvironmentVariables)
 
@@ -17,13 +19,20 @@ async function main() {
 
   let app: Application
 
-  if (stampConfig) {
-    logger.debug('stamp config', stampConfig)
+  if (stampsConfig) {
+    logger.debug('stamps config', stampsConfig)
     const stampManager = new StampsManager()
     logger.info('starting postage stamp manager')
-    await stampManager.start(stampConfig)
+    await stampManager.start(stampsConfig)
     logger.info('starting the proxy')
     app = createApp(appConfig, stampManager)
+  } else if (contentsConfig) {
+    logger.debug('contents config', contentsConfig)
+    const contentsManager = new ContentsManager()
+    logger.info('starting postage stamp manager')
+    await contentsManager.start(contentsConfig)
+    logger.info('starting the proxy')
+    app = createApp(appConfig)
   } else {
     logger.info('starting the app without postage stamps management')
     app = createApp(appConfig)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,13 @@ async function main() {
 
   let app: Application
 
+  if (contentsConfig) {
+    logger.debug('contents config', contentsConfig)
+    const contentsManager = new ContentsManager()
+    logger.info('starting postage content manager')
+    await contentsManager.start(contentsConfig)
+  }
+
   if (stampsConfig) {
     logger.debug('stamps config', stampsConfig)
     const stampManager = new StampsManager()
@@ -26,13 +33,6 @@ async function main() {
     await stampManager.start(stampsConfig)
     logger.info('starting the proxy')
     app = createApp(appConfig, stampManager)
-  } else if (contentsConfig) {
-    logger.debug('contents config', contentsConfig)
-    const contentsManager = new ContentsManager()
-    logger.info('starting postage stamp manager')
-    await contentsManager.start(contentsConfig)
-    logger.info('starting the proxy')
-    app = createApp(appConfig)
   } else {
     logger.info('starting the app without postage stamps management')
     app = createApp(appConfig)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function main() {
   if (contentConfig) {
     logger.debug('content config', contentConfig)
     const contentManager = new ContentManager()
-    logger.info('starting postage content manager')
+    logger.info('starting content manager')
     await contentManager.start(contentConfig)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import { Application } from 'express'
 
 import { createApp } from './server'
 import { StampsManager } from './stamps'
-import { getAppConfig, getServerConfig, getStampsConfig, EnvironmentVariables, getContentsConfig } from './config'
+import { getAppConfig, getServerConfig, getStampsConfig, EnvironmentVariables, getContentConfig } from './config'
 import { logger, subscribeLogServerRequests } from './logger'
-import { ContentsManager } from './contents'
+import { ContentManager } from './content'
 
 async function main() {
   // Configuration
   const stampsConfig = getStampsConfig(process.env as EnvironmentVariables)
-  const contentsConfig = getContentsConfig(process.env as EnvironmentVariables)
+  const contentConfig = getContentConfig(process.env as EnvironmentVariables)
   const appConfig = getAppConfig(process.env as EnvironmentVariables)
   const { hostname, port } = getServerConfig(process.env as EnvironmentVariables)
 
@@ -19,11 +19,11 @@ async function main() {
 
   let app: Application
 
-  if (contentsConfig) {
-    logger.debug('contents config', contentsConfig)
-    const contentsManager = new ContentsManager()
+  if (contentConfig) {
+    logger.debug('content config', contentConfig)
+    const contentManager = new ContentManager()
     logger.info('starting postage content manager')
-    await contentsManager.start(contentsConfig)
+    await contentManager.start(contentConfig)
   }
 
   if (stampsConfig) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ async function main() {
     logger.debug('content config', contentConfig)
     const contentManager = new ContentManager()
     logger.info('starting content manager')
-    await contentManager.start(contentConfig)
+    contentManager.start(contentConfig)
   }
 
   if (stampsConfig) {

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -185,20 +185,20 @@ export class StampsManager {
   }
 
   public async refreshStampsReupload(beeApi: Bee): Promise<void> {
-    logger.info('checking pinned content')
     const pins = await beeApi.getAllPins()
 
     if (!pins.length) {
-      logger.info(`  no pins found`)
+      logger.info(`no pins found`)
     } else {
+      logger.info(`checking pinned content (${pins.length} pins)`)
       pins.forEach(async pin => {
         const isRetrievable = await beeApi.isReferenceRetrievable(pin)
-        logger.info(`pin ${pin} ${isRetrievable ? 'is retrievable' : 'is not retrievable'}`)
 
         if (!isRetrievable && !this.isReuploading) {
           this.isReuploading = true
           await beeApi.reuploadPinnedData(pin)
           this.isReuploading = false
+          logger.info(`pinned content reuploaded: ${pin}`)
         }
       })
     }

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -1,4 +1,4 @@
-import { BeeDebug, PostageBatch, BatchId, Bee } from '@ethersphere/bee-js'
+import { BeeDebug, PostageBatch, BatchId } from '@ethersphere/bee-js'
 import client from 'prom-client'
 import type { StampsConfig, StampsConfigAutobuy, StampsConfigExtends } from './config'
 import { logger } from './logger'

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -154,7 +154,6 @@ export class StampsManager {
   private interval?: ReturnType<typeof setInterval>
   private isBuyingStamp?: boolean = false
   private extendingStamps: string[] = []
-  private isReuploading?: boolean = false
 
   /**
    * Get postage stamp that should be replaced in a the proxy request header

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -154,8 +154,7 @@ export class StampsManager {
   private interval?: ReturnType<typeof setInterval>
   private isBuyingStamp?: boolean = false
   private extendingStamps: string[] = []
-  // private isReuploading?: boolean = false
-
+  private isReuploading?: boolean = false
 
   /**
    * Get postage stamp that should be replaced in a the proxy request header
@@ -193,15 +192,14 @@ export class StampsManager {
       logger.info(`  no pins found`)
     } else {
       pins.forEach(async pin => {
-        const bool = await beeApi.isReferenceRetrievable(pin)
-        logger.info(`pin ${pin} ${bool ? 'is retrievable' : 'is not retrievable'}`)
-        /* const isRetrievable = await beeApi.isReferenceRetrievable(pin)
+        const isRetrievable = await beeApi.isReferenceRetrievable(pin)
+        logger.info(`pin ${pin} ${isRetrievable ? 'is retrievable' : 'is not retrievable'}`)
 
         if (!isRetrievable && !this.isReuploading) {
           this.isReuploading = true
           await beeApi.reuploadPinnedData(pin)
           this.isReuploading = false
-        } */
+        }
       })
     }
   }

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -184,26 +184,6 @@ export class StampsManager {
     throw new Error('No postage stamp')
   }
 
-  public async refreshStampsReupload(beeApi: Bee): Promise<void> {
-    const pins = await beeApi.getAllPins()
-
-    if (!pins.length) {
-      logger.info(`no pins found`)
-    } else {
-      logger.info(`checking pinned content (${pins.length} pins)`)
-      pins.forEach(async pin => {
-        const isRetrievable = await beeApi.isReferenceRetrievable(pin)
-
-        if (!isRetrievable && !this.isReuploading) {
-          this.isReuploading = true
-          await beeApi.reuploadPinnedData(pin)
-          this.isReuploading = false
-          logger.info(`pinned content reuploaded: ${pin}`)
-        }
-      })
-    }
-  }
-
   /**
    * Refresh stamps from the bee node and if needed buy new stamp
    *

--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -1,6 +1,6 @@
 import { BeeDebug, PostageBatch, BatchId, Bee } from '@ethersphere/bee-js'
 import client from 'prom-client'
-import type { StampsConfig, StampsConfigAutobuy, StampsConfigExtends, StampsConfigReupload } from './config'
+import type { StampsConfig, StampsConfigAutobuy, StampsConfigExtends } from './config'
 import { logger } from './logger'
 import { register } from './metrics'
 
@@ -284,7 +284,7 @@ export class StampsManager {
   async verifyUsableStamps(
     beeDebug: BeeDebug,
     ttlMin: number,
-    config: StampsConfigAutobuy | StampsConfigExtends | StampsConfigReupload,
+    config: StampsConfigAutobuy | StampsConfigExtends,
     amount: string,
   ) {
     for (let i = 0; i < this.usableStamps!.length; i++) {
@@ -334,10 +334,8 @@ export class StampsManager {
 
       if (config.mode === 'autobuy') {
         refreshStamps = async () => this.refreshStampsAutobuy(config, new BeeDebug(config.beeDebugApiUrl))
-      } else if (config.mode === 'extendsTTL') {
-        refreshStamps = async () => this.refreshStampsExtends(config, new BeeDebug(config.beeDebugApiUrl))
       } else {
-        refreshStamps = async () => this.refreshStampsReupload(new Bee(config.beeDebugApiUrl))
+        refreshStamps = async () => this.refreshStampsExtends(config, new BeeDebug(config.beeDebugApiUrl))
       }
       this.stop()
       await refreshStamps()


### PR DESCRIPTION
Closes #309 

So that the content is available for other nodes on the network. It can be done using the /stewardship [endpoint](https://docs.ethswarm.org/api/#tag/Stewardship/paths/~1stewardship~1%7Breference%7D/put), by using the hashes from the list of [pinned nodes](https://docs.ethswarm.org/api/#tag/Pinning/paths/~1pins/get).

There could be a new environment variable (REUPLOAD_PERIOD) which would define the time when the reupload would happen.