### PR TITLE
fix: start server before stamp manager is ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ async function main() {
     logger.debug('stamps config', stampsConfig)
     const stampManager = new StampsManager()
     logger.info('starting postage stamp manager')
-    await stampManager.start(stampsConfig)
+    stampManager.start(stampsConfig)
     logger.info('starting the proxy')
     app = createApp(appConfig, stampManager)
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { AppConfig, DEFAULT_HOSTNAME } from './config'
 import { fetchBeeIdentity, getHashedIdentity, HASHED_IDENTITY_HEADER } from './identity'
 import { logger } from './logger'
 import { register } from './metrics'
-import { checkReadiness } from './readiness'
+import { checkReadiness, ReadinessStatus } from './readiness'
 import type { StampsManager } from './stamps'
 
 const SWARM_STAMP_HEADER = 'swarm-postage-batch-id'
@@ -113,8 +113,10 @@ export const createApp = (
   app.get('/readiness', async (_req, res) => {
     const readinessStatus = await checkReadiness(bee, beeDebug, stampManager)
 
-    if (readinessStatus === 'OK') {
+    if (readinessStatus === ReadinessStatus.OK) {
       res.end('OK')
+    } else if (readinessStatus === ReadinessStatus.NO_STAMP) {
+      res.status(503).end(readinessStatus)
     } else {
       res.status(502).end(readinessStatus)
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,12 +111,12 @@ export const createApp = (
 
   // Readiness endpoint
   app.get('/readiness', async (_req, res) => {
-    const ready = await checkReadiness(bee, beeDebug, stampManager)
+    const readinessStatus = await checkReadiness(bee, beeDebug, stampManager)
 
-    if (ready) {
+    if (readinessStatus === 'OK') {
       res.end('OK')
     } else {
-      res.status(502).end('Bad Gateway')
+      res.status(502).end(readinessStatus)
     }
   })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,5 +16,5 @@ export function getErrorMessage(error: unknown): string | undefined {
     return error
   }
 
-  return undefined
+  return String(error)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,3 +6,15 @@
 export async function sleep(ms: number): Promise<void> {
   return new Promise<void>(resolve => setTimeout(() => resolve(), ms))
 }
+
+export function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  return undefined
+}

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -102,10 +102,10 @@ describe('GET /readiness', () => {
 
     expect(res.text).toEqual('OK')
   })
-  it('should return 502 & Bad Gateway', async () => {
+  it('should return 502', async () => {
     const res = await request(appWrong).get(`/readiness`).expect(502)
 
-    expect(res.text).toEqual('Bad Gateway')
+    expect(res.text).toEqual('OTHER_ERROR')
   })
 
   it('with authorization enabled should return 403 & Forbidden', async () => {
@@ -114,10 +114,10 @@ describe('GET /readiness', () => {
     expect(res.text).toEqual('Forbidden')
   })
 
-  it('with authorization enabled should return 502 & Bad Gateway', async () => {
+  it('with authorization enabled should return 502', async () => {
     const res = await request(appAuthWrong).get(`/readiness`).set('authorization', authorization).expect(502)
 
-    expect(res.text).toEqual('Bad Gateway')
+    expect(res.text).toEqual('OTHER_ERROR')
   })
 
   it('with authorization enabled should return 200 & OK', async () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -2,6 +2,8 @@ import { getErrorMessage } from '../src/utils'
 
 test('getErrorMessage', () => {
   expect(getErrorMessage('error')).toEqual('error')
+  expect(getErrorMessage(42)).toEqual('42')
+  expect(getErrorMessage(true)).toEqual('true')
   expect(getErrorMessage(new Error('error'))).toEqual('error')
   expect(getErrorMessage(new Error())).toEqual('')
   expect(getErrorMessage(undefined)).toEqual('undefined')

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,0 +1,7 @@
+import { getErrorMessage } from '../src/utils'
+
+test('getErrorMessage', () => {
+  expect(getErrorMessage('error')).toEqual('error')
+  expect(getErrorMessage(new Error('error'))).toEqual('error')
+  expect(getErrorMessage(undefined)).toEqual(undefined)
+})

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -3,5 +3,6 @@ import { getErrorMessage } from '../src/utils'
 test('getErrorMessage', () => {
   expect(getErrorMessage('error')).toEqual('error')
   expect(getErrorMessage(new Error('error'))).toEqual('error')
-  expect(getErrorMessage(undefined)).toEqual(undefined)
+  expect(getErrorMessage(new Error())).toEqual('')
+  expect(getErrorMessage(undefined)).toEqual('undefined')
 })


### PR DESCRIPTION
Not sure about the 5xx HTTP status code usage..

During startup period, `/readiness` is `502` with message `NO_STAMP`, and `/health` is `200 OK`