### PR TITLE
docs: change postage_refresh_period to be in millis

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm run start
 | POSTAGE_USAGE_THRESHOLD | 0.7                         | Usage percentage at which new postage stamp will be bought (value between 0 and 1).                        |
 | POSTAGE_USAGE_MAX       | 0.9                         | Usage percentage at which existing postage stamp should not be considered viable ( values 0 to 1).         |
 | POSTAGE_TTL_MIN         | `autoplay`: 5 \* POSTAGE_REFRESH_PERIOD. `extends TTL` undefined | In `autobuy`, Minimal time to live for the postage stamps to still be considered for upload (in seconds). In `extends TTL` is mandatory and required to be above 60 seconds  |
-| POSTAGE_REFRESH_PERIOD  | 60                          | How frequently are the postage stamps checked in seconds.                                                  |
+| POSTAGE_REFRESH_PERIOD  | 60000                       | How frequently are the postage stamps checked in milliseconds.                                             |
 | CID_SUBDOMAINS          | false                       | Enables Bzz.link subdomain translation functionality for CIDs.                                             |
 | ENS_SUBDOMAINS          | false                       | Enables Bzz.link subdomain translation functionality for ENS.                                              |
 | REMOVE_PIN_HEADER       | true                        | Removes swarm-pin header on all proxy requests.                                                            |

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ export function getStampsConfig({
   POSTAGE_REFRESH_PERIOD,
   POSTAGE_EXTENDSTTL,
 }: EnvironmentVariables = {}): StampsConfig | undefined {
-  const refreshPeriod = Number(POSTAGE_REFRESH_PERIOD || DEFAULT_POSTAGE_REFRESH_PERIOD)
+  const refreshPeriod = Number(POSTAGE_REFRESH_PERIOD) || DEFAULT_POSTAGE_REFRESH_PERIOD
   const beeDebugApiUrl = BEE_DEBUG_API_URL || DEFAULT_BEE_DEBUG_API_URL
 
   // Start in hardcoded mode


### PR DESCRIPTION
As per the docs:

`POSTAGE_REFRESH_PERIOD | 60 | How frequently are the postage stamps checked in seconds.`
