### PR TITLE
fix: fix resetting isBuyingStamp

### DIFF
--- a/src/stamps.ts
+++ b/src/stamps.ts
@@ -244,18 +244,20 @@ export class StampsManager {
       if (!this.isBuyingStamp) {
         if (this.usableStamps.length === 0) {
           this.isBuyingStamp = true
-          const { stamp: newStamp } = await buyNewStamp(depth, amount, beeDebug)
+          try {
+            const { stamp: newStamp } = await buyNewStamp(depth, amount, beeDebug)
 
-          // Add the bought postage stamp
-          this.usableStamps.push(newStamp)
+            // Add the bought postage stamp
+            this.usableStamps.push(newStamp)
+          } finally {
+            this.isBuyingStamp = false
+          }
         } else {
           await this.verifyUsableStamps(beeDebug, ttlMin, config, amount)
         }
       }
     } catch (e) {
       logger.error('failed to refresh on extends postage stamps', e)
-    } finally {
-      this.isBuyingStamp = false
     }
   }
 


### PR DESCRIPTION
So there was this issue...

`setInterval` runs, `isBuyingStamp` is `false`, so a new stamp starts being purchased. It takes it a while to become usable and stuff, so by that time another cycle of `setInterval` runs, and its `finally` block resets `isBuyingStamp`, so on next run it can be a double purchase.