### PR TITLE
fix: add missing sleep in wait for stamp usable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,8 @@ export async function waitForStampUsable(beeDebug: BeeDebug, batchId: string): P
 
       if (batch.usable) {
         return
+      } else {
+        await sleep(3000)
       }
     } catch {
       await sleep(3000)


### PR DESCRIPTION
Does not affect 1.8, but will spam requests in 1.9 until we remove the workaround logic