### PR TITLE
ci: use a bee-runner App token for release-please

### DIFF
--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -11,10 +11,25 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BEE_RUNNER_APP_ID }}
+          private-key: ${{ secrets.BEE_RUNNER_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: gateway-proxy
+          # contents:      commits, branches, tags and the GitHub release
+          # pull-requests: the release PR
+          # issues:        the "autorelease: pending"/"autorelease: tagged" labels
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
-          token: ${{ secrets.GHA_PAT_ADVANCED }}
+          token: ${{ steps.app-token.outputs.token }}
           release-type: node
           package-name: gateway-proxy
           bump-minor-pre-major: true


### PR DESCRIPTION
`release_github.yaml` has been broken since at least 17 Aug because of `Bad credentials`. The `GHA_PAT_ADVANCED` org secret is no longer working. It was shared with this repo correctly; the stored token itself is dead. This is the same fix as bee-docs#843.

This change creates a short-lived token from the `bee-runner` App. It works only on this repo and can read and write contents, pull requests, and issues. We need the `issues` permission for release-please's `autorelease:` labels.

We use an App token instead of `GITHUB_TOKEN` because the `publish_*` workflows run when a `release` is created. `GITHUB_TOKEN` releases don't trigger this event.
